### PR TITLE
Force https

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,7 +2,10 @@ location ^~ YNH_EXAMPLE_PATH {
   alias YNH_WWW_PATH;
   try_files $uri $uri/ @monica;
   index index.php;
-
+    # Force https
+  if ($scheme = http) {
+    rewrite ^ https://$server_name$request_uri? permanent;
+  }
   location ~ \.php {
     fastcgi_split_path_info ^(.+?\.php)(/.*)$;
     fastcgi_pass unix:/run/php/php7.0-fpm.sock;


### PR DESCRIPTION
I observed if we open monica.domain.tld it opens in http. To force https by default I added 
 # Force https
  if ($scheme = http) {
    rewrite ^ https://$server_name$request_uri? permanent;
  }