### PR TITLE
Add path support to install args

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,16 @@
                 "example": "monica.com"
             },
             {
+                "name": "path",
+                "type": "path",
+                "ask": {
+                    "en": "Choose a path for Monica",
+                    "fr": "Choisissez un chemin pour Monica"
+                },
+                "example": "/monica",
+                "default": "/monica"
+            },
+            {
                 "name": "admin",
                 "type": "user",
                 "ask": {


### PR DESCRIPTION
The upstream issue (https://github.com/monicahq/monica/issues/139) preventing installation into subdirectories was just fixed, so now the manifest should allow setting the path for the install.